### PR TITLE
Fix Claude code review PR permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- Change `pull-requests` permission from `read` to `write` in `claude-code-review.yml`
- The review action was running successfully but couldn't post comments back to PRs

## Test plan
- [ ] This PR itself should get a Claude review comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)