### PR TITLE
Smithery score 45→93+ and v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-24
+
+### Added
+- smithery.yaml with configSchema for Smithery registry integration
+- Server icon via MCP `icons` field for Smithery and client display
+- Parameter descriptions on all 22 parameterized tools for MCP schema compliance
+
+[1.1.0]: https://github.com/j4th/mtg-mcp-server/compare/v1.0.1...v1.1.0
+
 ## [1.0.0] - 2026-03-23
 
 ### Added

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1a2e"/>
+      <stop offset="100%" stop-color="#16213e"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#c9a227"/>
+      <stop offset="100%" stop-color="#e8d374"/>
+    </linearGradient>
+  </defs>
+  <!-- Card shape background -->
+  <rect x="56" y="32" width="400" height="448" rx="24" ry="24" fill="url(#bg)" stroke="url(#ring)" stroke-width="6"/>
+  <!-- Inner card border -->
+  <rect x="80" y="56" width="352" height="400" rx="16" ry="16" fill="none" stroke="#c9a227" stroke-width="2" opacity="0.5"/>
+  <!-- Pentagon (mana symbol shape) -->
+  <polygon points="256,120 340,178 308,272 204,272 172,178" fill="none" stroke="url(#ring)" stroke-width="4" stroke-linejoin="round"/>
+  <!-- MTG text -->
+  <text x="256" y="360" text-anchor="middle" font-family="Georgia,serif" font-size="72" font-weight="bold" fill="url(#ring)" letter-spacing="8">MTG</text>
+  <!-- MCP subtitle -->
+  <text x="256" y="410" text-anchor="middle" font-family="Georgia,serif" font-size="32" fill="#c9a227" opacity="0.7" letter-spacing="12">MCP</text>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mtg-mcp-server"
-version = "1.0.1"
+version = "1.1.0"
 description = "Unified MCP server providing Magic: The Gathering data to AI assistants"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -4,12 +4,12 @@
     "title": "MTG MCP Server",
     "description": "Magic: The Gathering data for AI — cards, combos, draft analytics, and Commander tools.",
     "repository": {"url": "https://github.com/j4th/mtg-mcp-server", "source": "github"},
-    "version": "1.0.1",
+    "version": "1.1.0",
     "packages": [
         {
             "registryType": "pypi",
             "identifier": "mtg-mcp-server",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "transport": {"type": "stdio"}
         }
     ]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,36 @@
+name: mtg-mcp-server
+description: >
+  Magic: The Gathering toolkit for AI agents — 23 tools spanning Scryfall card
+  search, Commander Spellbook combo detection, 17Lands draft analytics, EDHREC
+  commander metagame data, and MTGJSON bulk card lookups. Includes 8 workflow
+  tools for deck analysis, budget upgrades, draft pick evaluation, and card
+  comparison across all sources. All APIs are public — no credentials required.
+configSchema:
+  type: object
+  properties:
+    MTG_MCP_ENABLE_17LANDS:
+      type: boolean
+      description: "Enable 17Lands draft analytics backend for card ratings and archetype stats"
+      default: true
+    MTG_MCP_ENABLE_EDHREC:
+      type: boolean
+      description: "Enable EDHREC commander metagame backend (uses undocumented endpoints)"
+      default: true
+    MTG_MCP_ENABLE_MTGJSON:
+      type: boolean
+      description: "Enable MTGJSON bulk card data for rate-limit-free lookups (~100MB download on first use)"
+      default: true
+    MTG_MCP_LOG_LEVEL:
+      type: string
+      description: "Server logging level"
+      default: "INFO"
+      enum: ["DEBUG", "INFO", "WARNING", "ERROR"]
+    MTG_MCP_SCRYFALL_RATE_LIMIT_MS:
+      type: number
+      description: "Minimum delay between Scryfall API calls in milliseconds"
+      default: 100
+    MTG_MCP_MTGJSON_REFRESH_HOURS:
+      type: number
+      description: "Hours between MTGJSON bulk data refreshes"
+      default: 24
+  required: []

--- a/src/mtg_mcp_server/providers/edhrec.py
+++ b/src/mtg_mcp_server/providers/edhrec.py
@@ -6,11 +6,13 @@ Uses undocumented EDHREC endpoints. Behind the MTG_MCP_ENABLE_EDHREC feature fla
 from __future__ import annotations
 
 import json
+from typing import Annotated
 
 import structlog
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.lifespan import lifespan
+from pydantic import Field
 
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.providers import ATTRIBUTION_EDHREC, TAGS_BETA, TOOL_ANNOTATIONS
@@ -46,8 +48,15 @@ def _get_client() -> EDHRECClient:
 
 @edhrec_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_BETA)
 async def commander_staples(
-    commander_name: str,
-    category: str | None = None,
+    commander_name: Annotated[
+        str, Field(description="Full commander name (e.g. 'Muldrotha, the Gravetide')")
+    ],
+    category: Annotated[
+        str | None,
+        Field(
+            description="Filter by card type: 'creatures', 'enchantments', 'artifacts', 'instants', 'sorceries', 'lands', 'planeswalkers'"
+        ),
+    ] = None,
 ) -> str:
     """Get the most-played cards for a commander with synergy scores and inclusion rates.
 
@@ -89,8 +98,11 @@ async def commander_staples(
 
 @edhrec_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_BETA)
 async def card_synergy(
-    card_name: str,
-    commander_name: str,
+    card_name: Annotated[str, Field(description="Card to check synergy for (e.g. 'Spore Frog')")],
+    commander_name: Annotated[
+        str,
+        Field(description="Commander to check synergy against (e.g. 'Muldrotha, the Gravetide')"),
+    ],
 ) -> str:
     """Get synergy data for a specific card with a specific commander.
 

--- a/src/mtg_mcp_server/providers/mtgjson.py
+++ b/src/mtg_mcp_server/providers/mtgjson.py
@@ -6,12 +6,13 @@ Uses the MTGJSON AtomicCards bulk file for in-memory card data.
 from __future__ import annotations
 
 import json
-from typing import Literal
+from typing import Annotated, Literal
 
 import structlog
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.lifespan import lifespan
+from pydantic import Field
 
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.providers import ATTRIBUTION_MTGJSON, TAGS_LOOKUP, TAGS_SEARCH, TOOL_ANNOTATIONS
@@ -53,7 +54,11 @@ def _get_client() -> MTGJSONClient:
 
 
 @mtgjson_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_LOOKUP)
-async def card_lookup(name: str) -> str:
+async def card_lookup(
+    name: Annotated[
+        str, Field(description="Card name for exact lookup, case-insensitive (e.g. 'Sol Ring')")
+    ],
+) -> str:
     """Look up a Magic card by exact name using MTGJSON bulk data.
 
     Returns full card details including mana cost, type, oracle text,
@@ -90,9 +95,14 @@ async def card_lookup(name: str) -> str:
 
 @mtgjson_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_SEARCH)
 async def card_search(
-    query: str,
-    search_field: Literal["name", "type", "text"] = "name",
-    limit: int = 20,
+    query: Annotated[str, Field(description="Substring to search for, case-insensitive")],
+    search_field: Annotated[
+        Literal["name", "type", "text"],
+        Field(
+            description="Field to search in — 'name' (card name), 'type' (type line), or 'text' (oracle text)"
+        ),
+    ] = "name",
+    limit: Annotated[int, Field(description="Maximum number of results to return")] = 20,
 ) -> str:
     """Search for Magic cards in MTGJSON bulk data.
 

--- a/src/mtg_mcp_server/providers/scryfall.py
+++ b/src/mtg_mcp_server/providers/scryfall.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from typing import Annotated
 
 import structlog
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.lifespan import lifespan
+from pydantic import Field
 
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.providers import (
@@ -54,8 +56,13 @@ def _get_client() -> ScryfallClient:
 
 @scryfall_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_SEARCH)
 async def search_cards(
-    query: str,
-    page: int = 1,
+    query: Annotated[
+        str,
+        Field(
+            description="Scryfall search query (e.g. 'f:commander id:sultai t:creature cmc<=3'). See scryfall.com/docs/syntax"
+        ),
+    ],
+    page: Annotated[int, Field(description="Page number for paginated results, 1-indexed")] = 1,
 ) -> str:
     """Search for Magic cards using Scryfall syntax.
 
@@ -81,8 +88,16 @@ async def search_cards(
 
 @scryfall_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_LOOKUP)
 async def card_details(
-    name: str,
-    fuzzy: bool = False,
+    name: Annotated[
+        str,
+        Field(description="Card name — exact match by default (e.g. 'Muldrotha, the Gravetide')"),
+    ],
+    fuzzy: Annotated[
+        bool,
+        Field(
+            description="Use fuzzy matching for approximate names (e.g. 'muldrotha' finds 'Muldrotha, the Gravetide')"
+        ),
+    ] = False,
 ) -> str:
     """Get full details for a Magic card by exact or fuzzy name."""
     client = _get_client()
@@ -115,7 +130,7 @@ async def card_details(
 
 @scryfall_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_PRICING)
 async def card_price(
-    name: str,
+    name: Annotated[str, Field(description="Card name for price lookup (exact match)")],
 ) -> str:
     """Get current prices for a Magic card. Prices update once per day."""
     client = _get_client()
@@ -140,7 +155,7 @@ async def card_price(
 
 @scryfall_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_LOOKUP)
 async def card_rulings(
-    name: str,
+    name: Annotated[str, Field(description="Card name to get official rulings for (exact match)")],
 ) -> str:
     """Get official rulings and clarifications for a Magic card."""
     client = _get_client()

--- a/src/mtg_mcp_server/providers/seventeen_lands.py
+++ b/src/mtg_mcp_server/providers/seventeen_lands.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from typing import Annotated
 
 import structlog
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.lifespan import lifespan
+from pydantic import Field
 
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.providers import ATTRIBUTION_17LANDS, TAGS_DRAFT, TOOL_ANNOTATIONS
@@ -43,8 +45,12 @@ def _get_client() -> SeventeenLandsClient:
 
 @draft_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_DRAFT)
 async def card_ratings(
-    set_code: str,
-    event_type: str = "PremierDraft",
+    set_code: Annotated[
+        str, Field(description="Three-letter set code (e.g. 'LCI', 'MKM', 'OTJ', 'BLB')")
+    ],
+    event_type: Annotated[
+        str, Field(description="Draft format — 'PremierDraft' (default) or 'TradDraft'")
+    ] = "PremierDraft",
 ) -> str:
     """Get win rate and draft performance data for cards in a set.
 
@@ -89,10 +95,18 @@ async def card_ratings(
 
 @draft_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_DRAFT)
 async def archetype_stats(
-    set_code: str,
-    start_date: str,
-    end_date: str,
-    event_type: str = "PremierDraft",
+    set_code: Annotated[
+        str, Field(description="Three-letter set code (e.g. 'LCI', 'MKM', 'OTJ', 'BLB')")
+    ],
+    start_date: Annotated[
+        str, Field(description="Start date in YYYY-MM-DD format (required by 17Lands API)")
+    ],
+    end_date: Annotated[
+        str, Field(description="End date in YYYY-MM-DD format (required by 17Lands API)")
+    ],
+    event_type: Annotated[
+        str, Field(description="Draft format — 'PremierDraft' (default) or 'TradDraft'")
+    ] = "PremierDraft",
 ) -> str:
     """Get win rates by color pair/archetype for a draft set.
 

--- a/src/mtg_mcp_server/providers/spellbook.py
+++ b/src/mtg_mcp_server/providers/spellbook.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 import structlog
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.lifespan import lifespan
+from pydantic import Field
 
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.providers import (
@@ -68,9 +69,16 @@ def _get_client() -> SpellbookClient:
 
 @spellbook_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_SEARCH | TAGS_COMBO)
 async def find_combos(
-    card_name: str,
-    color_identity: str | None = None,
-    limit: int = 10,
+    card_name: Annotated[
+        str, Field(description="Card name to search for combos (e.g. 'Muldrotha, the Gravetide')")
+    ],
+    color_identity: Annotated[
+        str | None,
+        Field(
+            description="Filter by color identity — name ('sultai'), letters ('BUG'), or 'wubrg'"
+        ),
+    ] = None,
+    limit: Annotated[int, Field(description="Maximum number of combos to return")] = 10,
 ) -> str:
     """Search for known combos involving a specific card.
 
@@ -98,7 +106,12 @@ async def find_combos(
 
 @spellbook_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_LOOKUP | TAGS_COMBO)
 async def combo_details(
-    combo_id: str,
+    combo_id: Annotated[
+        str,
+        Field(
+            description="Spellbook combo ID from find_combos results (e.g. '1414-2730-5131-5256')"
+        ),
+    ],
 ) -> str:
     """Get detailed steps for a specific combo by its Spellbook ID.
 
@@ -139,8 +152,10 @@ async def combo_details(
 
 @spellbook_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMBO)
 async def find_decklist_combos(
-    commanders: list[str],
-    decklist: list[str],
+    commanders: Annotated[
+        list[str], Field(description="Commander card name(s) (e.g. ['Muldrotha, the Gravetide'])")
+    ],
+    decklist: Annotated[list[str], Field(description="List of card names in the main deck")],
 ) -> str:
     """Find combos present in (or nearly present in) a Commander decklist.
 
@@ -172,8 +187,10 @@ async def find_decklist_combos(
 
 @spellbook_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMBO)
 async def estimate_bracket(
-    commanders: list[str],
-    decklist: list[str],
+    commanders: Annotated[
+        list[str], Field(description="Commander card name(s) (e.g. ['Muldrotha, the Gravetide'])")
+    ],
+    decklist: Annotated[list[str], Field(description="List of card names in the main deck")],
 ) -> str:
     """Estimate the Commander bracket (power level) for a decklist.
 

--- a/src/mtg_mcp_server/server.py
+++ b/src/mtg_mcp_server/server.py
@@ -16,7 +16,7 @@ import sys
 import structlog
 from fastmcp import FastMCP
 from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
-from mcp.types import ToolAnnotations
+from mcp.types import Icon, ToolAnnotations
 
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.logging import configure_logging
@@ -31,6 +31,7 @@ from mtg_mcp_server.workflows.server import workflow_mcp
 mcp = FastMCP(
     "MTG",
     mask_error_details=True,
+    icons=[Icon(src="https://raw.githubusercontent.com/j4th/mtg-mcp-server/main/icon.svg")],
     instructions=(
         "Magic: The Gathering data and analytics server.\n\n"
         "Tool categories:\n"

--- a/src/mtg_mcp_server/workflows/server.py
+++ b/src/mtg_mcp_server/workflows/server.py
@@ -13,11 +13,13 @@ so tool names stay clean (e.g. ``commander_overview``, not
 from __future__ import annotations
 
 from contextlib import AsyncExitStack
+from typing import Annotated
 
 import structlog
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.lifespan import lifespan
+from pydantic import Field
 
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.providers import (
@@ -127,7 +129,11 @@ async def _progress(ctx: Context, step: int, total: int) -> None:
 
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMMANDER)
-async def commander_overview(commander_name: str) -> str:
+async def commander_overview(
+    commander_name: Annotated[
+        str, Field(description="Commander card name (e.g. 'Muldrotha, the Gravetide')")
+    ],
+) -> str:
     """Comprehensive commander profile combining data from all available sources.
 
     Returns card details, top combos, EDHREC staples, and synergy scores.
@@ -151,7 +157,12 @@ async def commander_overview(commander_name: str) -> str:
 
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMMANDER)
-async def evaluate_upgrade(card_name: str, commander_name: str) -> str:
+async def evaluate_upgrade(
+    card_name: Annotated[
+        str, Field(description="Card to evaluate for the deck (e.g. 'Spore Frog')")
+    ],
+    commander_name: Annotated[str, Field(description="Commander the deck is built around")],
+) -> str:
     """Assess whether a card is worth adding to a specific commander deck.
 
     Returns card details, price, synergy score, and combos enabled for the caller to assess.
@@ -177,9 +188,14 @@ async def evaluate_upgrade(card_name: str, commander_name: str) -> str:
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_DRAFT)
 async def draft_pack_pick(
-    pack: list[str],
-    set_code: str,
-    current_picks: list[str] | None = None,
+    pack: Annotated[list[str], Field(description="List of card names currently in the draft pack")],
+    set_code: Annotated[
+        str, Field(description="Three-letter set code for the draft format (e.g. 'LCI', 'MKM')")
+    ],
+    current_picks: Annotated[
+        list[str] | None,
+        Field(description="Cards already drafted — enables color fit analysis when provided"),
+    ] = None,
 ) -> str:
     """Rank cards in a draft pack using 17Lands win rate data.
 
@@ -201,9 +217,9 @@ async def draft_pack_pick(
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMMANDER)
 async def suggest_cuts(
-    decklist: list[str],
-    commander_name: str,
-    num_cuts: int = 5,
+    decklist: Annotated[list[str], Field(description="List of card names in the deck")],
+    commander_name: Annotated[str, Field(description="Commander the deck is built around")],
+    num_cuts: Annotated[int, Field(description="Number of cut candidates to suggest")] = 5,
 ) -> str:
     """Identify the weakest cards to cut from a commander decklist.
 
@@ -226,8 +242,8 @@ async def suggest_cuts(
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMMANDER)
 async def card_comparison(
-    cards: list[str],
-    commander_name: str,
+    cards: Annotated[list[str], Field(description="2-5 card names to compare side-by-side")],
+    commander_name: Annotated[str, Field(description="Commander the deck is built around")],
     ctx: Context,
 ) -> str:
     """Compare 2-5 cards side-by-side for a specific commander deck.
@@ -259,9 +275,13 @@ async def card_comparison(
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMMANDER | TAGS_PRICING)
 async def budget_upgrade(
-    commander_name: str,
-    budget: float,
-    num_suggestions: int = 10,
+    commander_name: Annotated[str, Field(description="Commander the deck is built around")],
+    budget: Annotated[
+        float, Field(description="Maximum price per card in USD (e.g. 5.0 for cards under $5)")
+    ],
+    num_suggestions: Annotated[
+        int, Field(description="Number of upgrade suggestions to return")
+    ] = 10,
     *,
     ctx: Context,
 ) -> str:
@@ -292,8 +312,10 @@ async def budget_upgrade(
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_COMMANDER)
 async def deck_analysis(
-    decklist: list[str],
-    commander_name: str,
+    decklist: Annotated[
+        list[str], Field(description="List of card names in the deck (99 cards for Commander)")
+    ],
+    commander_name: Annotated[str, Field(description="Commander the deck is built around")],
     ctx: Context,
 ) -> str:
     """Full decklist health check — mana curve, colors, combos, bracket, budget, synergy.
@@ -323,8 +345,12 @@ async def deck_analysis(
 
 @workflow_mcp.tool(annotations=TOOL_ANNOTATIONS, tags=TAGS_DRAFT)
 async def set_overview(
-    set_code: str,
-    event_type: str = "PremierDraft",
+    set_code: Annotated[
+        str, Field(description="Three-letter set code for the draft format (e.g. 'LCI', 'MKM')")
+    ],
+    event_type: Annotated[
+        str, Field(description="Draft format — 'PremierDraft' (default) or 'TradDraft'")
+    ] = "PremierDraft",
     *,
     ctx: Context,
 ) -> str:

--- a/tests/test_parameter_descriptions.py
+++ b/tests/test_parameter_descriptions.py
@@ -14,7 +14,7 @@ from mtg_mcp_server.workflows.server import workflow_mcp
 
 
 @pytest.mark.parametrize(
-    "server,server_name",
+    ("server", "server_name"),
     [
         (scryfall_mcp, "scryfall"),
         (spellbook_mcp, "spellbook"),

--- a/uv.lock
+++ b/uv.lock
@@ -851,7 +851,7 @@ wheels = [
 
 [[package]]
 name = "mtg-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- Add parameter descriptions to all 46 tool parameters across 22 tools using `Annotated[type, Field(description=...)]` for MCP JSON Schema compliance (+11 pts)
- Add `smithery.yaml` with `configSchema` (6 optional properties mapping to existing `Settings` fields) and server description (+35 pts)
- Add `icon.svg` and MCP `icons` field on the FastMCP constructor (+7 pts)
- Bump version to 1.1.0 in `pyproject.toml`, `server.json`, and `CHANGELOG.md`

Expected Smithery score: **93-98/100** (up from 45)

## Test plan
- [x] TDD: failing test written first (`test_parameter_descriptions.py`), confirmed 6 failures
- [x] All 396 tests pass after implementation (green phase)
- [x] `mise run check` passes (lint + typecheck + test, 93% coverage)
- [x] MCP schema verification script confirms all 23 tools have parameter descriptions
- [x] No breaking changes — all existing tool names and behavior preserved
- [ ] Verify Smithery score after merge and publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)