### PR TITLE
Add CDN settle time to PyPI propagation wait

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,15 +45,17 @@ jobs:
         run: |
           PKG_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           echo "Waiting for mtg-mcp-server==${PKG_VERSION} on PyPI..."
-          for i in $(seq 1 12); do
+          for i in $(seq 1 30); do
             if curl -sf "https://pypi.org/pypi/mtg-mcp-server/${PKG_VERSION}/json" > /dev/null 2>&1; then
-              echo "Package available on PyPI after ~$((i * 10))s"
+              echo "Package found on PyPI after ~$((i * 10))s, waiting 30s for CDN propagation..."
+              sleep 30
+              echo "Ready."
               exit 0
             fi
-            echo "Attempt $i/12 — not yet indexed, waiting 10s..."
+            echo "Attempt $i/30 — not yet indexed, waiting 10s..."
             sleep 10
           done
-          echo "::warning::PyPI index propagation took longer than 2 minutes"
+          echo "::warning::PyPI index propagation took longer than 5 minutes"
           exit 1
 
       - name: Publish to MCP Registry


### PR DESCRIPTION
## Summary
- Add 30s sleep after PyPI JSON API confirms package availability, before MCP Registry publish
- Increase max wait from 2min (12x10s) to 5min (30x10s) for slow propagation
- Fixes race condition where MCP Registry's PyPI check hits a different CDN edge than our probe

v1.1.1 release failed on this — the wait step found the package after 10s but the MCP Registry got a 404 less than 1s later.

## Test plan
- [x] Re-ran v1.1.1 publish manually — succeeded after CDN had time to propagate
- [ ] Next release should pass without manual re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)