### PR TITLE
Fix server version and add Smithery publish to CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@
 # For manual local publishing only:
 # UV_PUBLISH_TOKEN=pypi-...
 
+# --- Smithery ---
+# Required for mise run smithery:metadata and smithery:publish.
+# Get token: npx @smithery/cli auth token
+SMITHERY_API_KEY=
+
 # --- Transport ---
 MTG_MCP_TRANSPORT=stdio              # stdio | http
 MTG_MCP_HTTP_PORT=8000

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,3 +62,52 @@ jobs:
         run: |
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish
+
+  smithery:
+    runs-on: ubuntu-latest
+    needs: pypi
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: jdx/mise-action@v4
+
+      - name: Install dependencies
+        run: mise run setup
+
+      - name: Generate config schema from SmitheryConfig
+        run: |
+          uv run python -c "
+          from mtg_mcp_server.smithery import SmitheryConfig
+          import json
+          print(json.dumps(SmitheryConfig.model_json_schema()))
+          " > /tmp/smithery-config-schema.json
+          echo "Generated schema:"
+          cat /tmp/smithery-config-schema.json
+
+      - name: Wait for Horizon to rebuild with new version
+        run: |
+          PKG_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          HORIZON_URL="https://mtg-mcp-server.fastmcp.app/mcp"
+          echo "Waiting for Horizon to serve version ${PKG_VERSION}..."
+          for i in $(seq 1 30); do
+            RESP=$(curl -sS -X POST "$HORIZON_URL" \
+              -H "Content-Type: application/json" \
+              -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' \
+              2>/dev/null || true)
+            SERVER_VER=$(echo "$RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',{}).get('serverInfo',{}).get('version',''))" 2>/dev/null || true)
+            if [ "$SERVER_VER" = "$PKG_VERSION" ]; then
+              echo "Horizon serving version ${PKG_VERSION} after ~$((i * 15))s"
+              exit 0
+            fi
+            echo "Attempt $i/30 — got version '${SERVER_VER}', waiting 15s..."
+            sleep 15
+          done
+          echo "::warning::Horizon did not update to ${PKG_VERSION} within 7.5 minutes — publishing anyway"
+
+      - name: Publish to Smithery with config schema
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: |
+          npx -y @smithery/cli mcp publish "https://mtg-mcp-server.fastmcp.app/mcp" \
+            -n @j4th/mtg-mcp-server \
+            --config-schema /tmp/smithery-config-schema.json

--- a/mise.toml
+++ b/mise.toml
@@ -108,6 +108,19 @@ run = [
 description = "Update Smithery registry metadata (requires SMITHERY_API_KEY)"
 run = "bash scripts/update_smithery_metadata.sh"
 
+[tasks."smithery:publish"]
+description = "Re-publish to Smithery with config schema (requires SMITHERY_API_KEY)"
+run = """
+uv run python -c "
+from mtg_mcp_server.smithery import SmitheryConfig
+import json
+print(json.dumps(SmitheryConfig.model_json_schema()))
+" > /tmp/smithery-config-schema.json
+npx -y @smithery/cli mcp publish "https://mtg-mcp-server.fastmcp.app/mcp" \
+  -n @j4th/mtg-mcp-server \
+  --config-schema /tmp/smithery-config-schema.json
+"""
+
 [tasks."smithery:check-schema"]
 description = "Verify smithery.yaml matches SmitheryConfig model"
 run = "uv run python scripts/check_smithery_schema.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mtg-mcp-server"
-version = "1.2.2"
+version = "1.2.3"
 description = "Unified MCP server providing Magic: The Gathering data to AI assistants"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -16,12 +16,12 @@
         "source": "github",
         "id": "1187666627"
     },
-    "version": "1.2.2",
+    "version": "1.2.3",
     "packages": [
         {
             "registryType": "pypi",
             "identifier": "mtg-mcp-server",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "transport": {"type": "stdio"},
             "runtimeHint": "uvx",
             "environmentVariables": [

--- a/src/mtg_mcp_server/server.py
+++ b/src/mtg_mcp_server/server.py
@@ -18,6 +18,7 @@ from fastmcp import FastMCP
 from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
 from mcp.types import Icon, ToolAnnotations
 
+from mtg_mcp_server import __version__
 from mtg_mcp_server.config import Settings
 from mtg_mcp_server.logging import configure_logging
 from mtg_mcp_server.providers.edhrec import edhrec_mcp
@@ -30,6 +31,7 @@ from mtg_mcp_server.workflows.server import workflow_mcp
 
 mcp = FastMCP(
     "MTG",
+    version=__version__,
     mask_error_details=True,
     website_url="https://github.com/j4th/mtg-mcp-server",
     icons=[

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -241,6 +241,13 @@ class TestServerMetadata:
 
         assert server.name == "MTG"
 
+    def test_server_version_from_package(self):
+        """Server version matches package version, not FastMCP version."""
+        from mtg_mcp_server import __version__
+        from mtg_mcp_server.server import mcp as server
+
+        assert server.version == __version__
+
     def test_server_website_url(self):
         """Server has a website URL configured."""
         from mtg_mcp_server.server import mcp as server

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "mtg-mcp-server"
-version = "1.2.2"
+version = "1.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

- Pass `__version__` to `FastMCP()` so MCP `initialize` reports package version (1.2.3) instead of FastMCP's version (3.1.1) — fixes Smithery showing wrong version
- Add `smithery` job to `publish.yml` that re-publishes to Smithery with `--config-schema` generated from `SmitheryConfig` Pydantic model — fixes "No config schema provided" warning and 0/25 Configuration UX score
- Horizon version polling (15s intervals, 7.5min timeout) prevents race between PyPI propagation and Smithery scanning a stale server build
- Add `smithery:publish` mise task for local use
- Add `SMITHERY_API_KEY` to `.env.example`

## Setup required

Add `SMITHERY_API_KEY` to GitHub Actions secrets (Settings > Secrets > Actions). Get token: `npx @smithery/cli auth token`

## Test plan

- [x] 436 tests pass (93% coverage)
- [x] `mise run check` — full lint + typecheck + test gate
- [ ] After merge + release: verify Smithery shows correct version and config schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>