### PR TITLE
Centralize description and add Smithery metadata to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,27 @@ jobs:
 
       - uses: jdx/mise-action@v4
 
-      - name: Verify server.json version matches pyproject.toml
+      - name: Verify server.json matches pyproject.toml
         run: |
-          PKG_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          SERVER_VERSION=$(python3 -c "import json; print(json.load(open('server.json'))['version'])")
-          PACKAGE_VERSION=$(python3 -c "import json; print(json.load(open('server.json'))['packages'][0]['version'])")
-          echo "pyproject.toml: $PKG_VERSION"
-          echo "server.json version: $SERVER_VERSION"
-          echo "server.json packages[0].version: $PACKAGE_VERSION"
-          if [ "$PKG_VERSION" != "$SERVER_VERSION" ] || [ "$PKG_VERSION" != "$PACKAGE_VERSION" ]; then
-            echo "::error::Version mismatch! Update server.json to match pyproject.toml ($PKG_VERSION)"
-            exit 1
-          fi
+          python3 -c "
+          import json, tomllib, sys
+          proj = tomllib.load(open('pyproject.toml', 'rb'))['project']
+          sj = json.load(open('server.json'))
+          errors = []
+          # Version check
+          for path, val in [('version', sj['version']), ('packages[0].version', sj['packages'][0]['version'])]:
+              if val != proj['version']:
+                  errors.append(f'server.json {path} ({val}) != pyproject.toml ({proj[\"version\"]})')
+          # Description check
+          if sj.get('description', '') != proj['description']:
+              errors.append(f'server.json description does not match pyproject.toml')
+              errors.append(f'  server.json:   {sj.get(\"description\", \"\")}')
+              errors.append(f'  pyproject.toml: {proj[\"description\"]}')
+          if errors:
+              for e in errors: print(f'::error::{e}')
+              sys.exit(1)
+          print(f'OK: version={proj[\"version\"]}, description matches')
+          "
 
       - name: Verify smithery.yaml matches SmitheryConfig
         run: uv run python scripts/check_smithery_schema.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,3 +121,8 @@ jobs:
           npx -y @smithery/cli mcp publish "https://mtg-mcp-server.fastmcp.app/mcp" \
             -n @j4th/mtg-mcp-server \
             --config-schema /tmp/smithery-config-schema.json
+
+      - name: Sync registry metadata from pyproject.toml
+        env:
+          SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+        run: bash scripts/update_smithery_metadata.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mtg-mcp-server"
 version = "1.2.3"
-description = "Unified MCP server providing Magic: The Gathering data to AI assistants"
+description = "Magic: The Gathering card search, combo lookup, draft analytics, and Commander tools."
 readme = "README.md"
 license = "MIT"
 authors = [{ name = "Justin Forth", email = "justinforth@gmail.com" }]

--- a/scripts/update_smithery_metadata.sh
+++ b/scripts/update_smithery_metadata.sh
@@ -1,22 +1,31 @@
 #!/usr/bin/env bash
 # Update Smithery registry metadata for mtg-mcp-server.
+# Reads description from pyproject.toml (single source of truth).
 # Requires SMITHERY_API_KEY env var (get via: npx @smithery/cli auth token)
 set -euo pipefail
 : "${SMITHERY_API_KEY:?Set SMITHERY_API_KEY (run: npx @smithery/cli auth token)}"
 SERVER="j4th/mtg-mcp-server"
 API="https://api.smithery.ai/servers/${SERVER}"
 
+# Build JSON payload from pyproject.toml (single source of truth for PyPI, MCP Registry, Smithery)
+PAYLOAD=$(python3 -c "
+import json, tomllib
+proj = tomllib.load(open('pyproject.toml', 'rb'))['project']
+print(json.dumps({
+    'displayName': 'MTG MCP Server',
+    'description': proj['description'],
+    'homepage': proj['urls']['Homepage'],
+}))
+")
+
 echo "Updating metadata for ${SERVER}..."
+echo "  Payload: ${PAYLOAD}"
 
 # PATCH display name, description, homepage
 HTTP_CODE=$(curl -sS -o /tmp/smithery_resp.json -w "%{http_code}" -X PATCH "$API" \
   -H "Authorization: Bearer $SMITHERY_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "displayName": "MTG MCP Server",
-    "description": "Magic: The Gathering data for AI — cards, combos, draft analytics, and Commander tools.",
-    "homepage": "https://github.com/j4th/mtg-mcp-server"
-  }')
+  -d "$PAYLOAD")
 if [[ "$HTTP_CODE" != 2* ]]; then
   echo "ERROR: PATCH metadata failed with HTTP $HTTP_CODE:" >&2
   cat /tmp/smithery_resp.json >&2
@@ -29,8 +38,7 @@ echo "  ✓ Metadata updated"
 [[ -f icon.svg ]] || { echo "ERROR: icon.svg not found in $(pwd)" >&2; exit 1; }
 HTTP_CODE=$(curl -sS -o /tmp/smithery_resp.json -w "%{http_code}" -X PUT "$API/icon" \
   -H "Authorization: Bearer $SMITHERY_API_KEY" \
-  -H "Content-Type: image/svg+xml" \
-  --data-binary @icon.svg)
+  -F "icon=@icon.svg;type=image/svg+xml")
 if [[ "$HTTP_CODE" != 2* ]]; then
   echo "ERROR: PUT icon failed with HTTP $HTTP_CODE:" >&2
   cat /tmp/smithery_resp.json >&2

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
     "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     "name": "io.github.j4th/mtg-mcp-server",
     "title": "MTG MCP Server",
-    "description": "Magic: The Gathering data for AI — cards, combos, draft analytics, and Commander tools.",
+    "description": "Magic: The Gathering card search, combo lookup, draft analytics, and Commander tools.",
     "websiteUrl": "https://github.com/j4th/mtg-mcp-server",
     "icons": [
         {


### PR DESCRIPTION
## Summary
- `pyproject.toml` is now the single source of truth for the project description, synced to PyPI, MCP Registry (`server.json`), and Smithery
- Metadata script reads from `pyproject.toml` instead of hardcoding values
- Fix icon upload to use multipart form data (was failing with raw binary)
- Add metadata sync step to Smithery publish job in CI
- CI build job now validates `server.json` description matches `pyproject.toml`

## Test plan
- [x] `mise run check` passes (436 tests, 93% coverage)
- [x] CI verification script confirms version + description match
- [ ] After merge + next release: verify Smithery registry shows correct description

🤖 Generated with [Claude Code](https://claude.com/claude-code)